### PR TITLE
chore: do not open browser when running the dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "check-types": "tsc",
-    "dev-sandbox-only": "cross-env NODE_ENV=development webpack-dev-server --color --progress",
+    "dev-sandbox-only": "cross-env NODE_ENV=development webpack-dev-server --color --progress --no-open",
     "dev-sandbox-and-native": "concurrently npm:build-watch npm:start",
     "build": "rm -rf dist && cross-env NODE_ENV=production webpack --color --progress && cd dist && zip -r ../PluginZip.zip ./*",
     "build-watch": "nodemon --watch 'src/**/* public/**/*' --exec \"npm run build\" -e '*'",


### PR DESCRIPTION
## Summary

This PR passes ` --no-open` parameter to `dev-sandbox-only` command. Before this, it opened localhost:8080 in the default browser. But that's not how we're supposed to test and develop the plugin. To remove the confusion, we'd better not open the url.