### PR TITLE
Fixed npm run command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This will install a very minimal React App, along with the RemNote plugin SDK (s
 Inside the plugin folder, run:
 
 ```bash
-npm run dev-sandbox-only
+npm run dev
 ```
 
 ## Resources


### PR DESCRIPTION
Changed the npm run command to 'npm run dev' as the old command seemed to be deprecated and not aligned with https://plugins.remnote.com/in-depth-tutorial/setup#start-your-plugin.