### PR TITLE
Fix LICENCE name and update year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Yoshihide Shiono
+Copyright (c) 2023 RemNote Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
### Summary 🎯

I think the LICENCE was copied without adapting the name and year, as reported in #12. Closes #12.

### Changes 🔁

- Change name to "RemNote Inc.".
- Update year to 2023
